### PR TITLE
Add prototype flag to Svelte tutorial

### DIFF
--- a/tutorial/simple-todos/01-creating-app.md
+++ b/tutorial/simple-todos/01-creating-app.md
@@ -12,7 +12,7 @@ Install the latest official Meteor release [following the steps in our docs](htt
 The easiest way to set up Meteor with Svelte is by using the command `meteor create` with the option `--svelte` and your project name:
 
 ```
-meteor create --svelte simple-todos-svelte
+meteor create --svelte simple-todos-svelte --prototype
 ```
 
 After this, Meteor will create all the necessary files for you. 


### PR DESCRIPTION
In 2.9, insecure will need to be added manually; for this tutorial not to be outdated, I will adjust its creation by passing the --prototype flag as shown in the [pr](https://github.com/meteor/meteor/pull/12220)