### PR TITLE
Remove parameters harmful for accessibility reasons

### DIFF
--- a/tutorial/simple-todos/01-creating-app.md
+++ b/tutorial/simple-todos/01-creating-app.md
@@ -150,7 +150,7 @@ As you can see, everything is small, as we are not adjusting the view port for m
   <meta http-equiv="x-ua-compatible" content="ie=edge"/>
   <meta
       name="viewport"
-      content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
+      content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, minimum-scale=1
   />
   <meta name="mobile-web-app-capable" content="yes"/>
   <meta name="apple-mobile-web-app-capable" content="yes"/>


### PR DESCRIPTION
UserScalable and maximumScale are extremely important for low-vision users, as they allow for content to be zoomed in. i realize this is an example, but if we're teaching people how to build apps, let's please make sure we actually teach proper best practices